### PR TITLE
Add single-page portfolio website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# my-portfolio-data-analyst
+# Portfolio: Ari Wahyudi - Senior Data Analyst
+
+This repository contains a simple single-page portfolio website. Open `index.html` in your browser to view the portfolio.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ari Wahyudi - Senior Data Analyst</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="navbar">
+        <nav>
+            <ul>
+                <li><a href="#home">Home</a></li>
+                <li><a href="#about">About</a></li>
+                <li><a href="#projects">Projects</a></li>
+                <li><a href="#resume">Resume</a></li>
+                <li><a href="#contact">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+    <section id="home" class="hero">
+        <h1>Ari Wahyudi</h1>
+        <h2>Senior Data Analyst</h2>
+        <p>Transforming data into strategic insights</p>
+        <a href="#projects" class="btn">View My Work</a>
+    </section>
+    <section id="about" class="about">
+        <h2>About Me</h2>
+        <p>I am a seasoned data analyst with a passion for turning complex data into actionable stories.</p>
+        <h3>Skills</h3>
+        <ul>
+            <li>SQL</li>
+            <li>Python</li>
+            <li>Tableau</li>
+            <li>Power BI</li>
+        </ul>
+    </section>
+    <section id="projects" class="projects">
+        <h2>Projects</h2>
+        <div class="project-card">
+            <h3>Sales Dashboard</h3>
+            <p>Interactive dashboard providing real-time sales insights.</p>
+            <p class="tools">Tools: Tableau, SQL</p>
+        </div>
+        <div class="project-card">
+            <h3>Customer Segmentation</h3>
+            <p>Clustering analysis for targeted marketing campaigns.</p>
+            <p class="tools">Tools: Python, scikit-learn</p>
+        </div>
+        <div class="project-card">
+            <h3>Financial Reporting Automation</h3>
+            <p>Automated monthly reporting for finance teams.</p>
+            <p class="tools">Tools: Python, Excel</p>
+        </div>
+    </section>
+    <section id="resume" class="resume">
+        <h2>Resume</h2>
+        <a href="resume.pdf" class="btn" download>Download Resume</a>
+    </section>
+    <section id="contact" class="contact">
+        <h2>Contact</h2>
+        <form>
+            <input type="text" name="name" placeholder="Name" required>
+            <input type="email" name="email" placeholder="Email" required>
+            <textarea name="message" placeholder="Message" required></textarea>
+            <button type="submit" class="btn">Send</button>
+        </form>
+    </section>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,90 @@
+body {
+    font-family: Arial, Helvetica, sans-serif;
+    margin: 0;
+    padding: 0;
+    color: #333;
+    background-color: #f4f7fb;
+}
+
+.navbar {
+    position: sticky;
+    top: 0;
+    background: #ffffff;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    z-index: 1000;
+}
+
+.navbar ul {
+    list-style: none;
+    display: flex;
+    justify-content: center;
+    margin: 0;
+    padding: 1rem;
+}
+
+.navbar li {
+    margin: 0 1rem;
+}
+
+.navbar a {
+    text-decoration: none;
+    color: #0056b3;
+    font-weight: bold;
+}
+
+.hero {
+    text-align: center;
+    padding: 6rem 1rem;
+    background-color: #e6efff;
+}
+
+.btn {
+    display: inline-block;
+    margin-top: 1rem;
+    padding: 0.75rem 1.5rem;
+    background-color: #007bff;
+    color: white;
+    text-decoration: none;
+    border-radius: 4px;
+}
+
+section {
+    text-align: center;
+    padding: 4rem 1rem;
+}
+
+.project-card {
+    background: white;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    padding: 1rem;
+    margin: 1rem auto;
+    max-width: 300px;
+}
+
+.project-card .tools {
+    color: #555;
+    font-size: 0.9rem;
+}
+
+form {
+    max-width: 400px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+}
+
+input, textarea {
+    padding: 0.5rem;
+    margin-bottom: 1rem;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+}
+
+button {
+    padding: 0.75rem;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- add portfolio webpage with hero, about, projects, resume, and contact
- style with light theme using soft blue and grey tones
- provide placeholder resume and updated README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68831c0067bc832bac8ed4b2b0b261a3